### PR TITLE
docs(readme): add donations to the readme with Paypal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/aalises/age-of-empires-II-api/badge.svg?branch=master)](https://coveralls.io/github/aalises/age-of-empires-II-api?branch=master)
 [![Docker Image](https://img.shields.io/badge/Docker%20image-latest-blue.svg?link=https://hub.docker.com/r/aalises/aoe2api/)](https://hub.docker.com/r/aalises/aoe2api/)
 
+
 API available at : https://age-of-empires-2-api.herokuapp.com
 
 Age of Empires II API created with:
@@ -237,4 +238,14 @@ Example call `/api/v1/technology/gold_mining`
   "description": "Work rate * 1.15 (15% faster)"
 }
 ```
+
+## Donations
+
+The Age of Empires II API was originally conceived as a pet project, and is using the free plan on Heroku. As some people is using it, we are running out of the free dyno hours on Heroku so the API is down.
+
+Help to keep it running! If you're using it as a teaching resource or for a project, consider sending a $7 donation to help keep the service up for one more month, as we will be able to upgrade to the Hobby plan on Heroku.
+
+[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=A3MTLTHWX686N&source=url)
+
+Become a backer!
 


### PR DESCRIPTION
Added the `donations` section on the README with a Paypal link to contribute to keeping the service up the if you are using it, as the free-running hours of the free plan of Heroku are depleted due to usage...